### PR TITLE
fix: add security attributes to external GitHub links (closes #23)

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
             <h3><span>Build</span>, Share & Explore</h3>
             <p class="tagline">A community-driven platform where developers showcase their creativity through interactive web projects</p>
             <div class="btn-container">
-                <a href="https://github.com/YadavAkhileshh/OpenPlayground" target="_blank" class="source-code-btn">
+                <a href="https://github.com/YadavAkhileshh/OpenPlayground" target="_blank" rel="noopener noreferrer" class="source-code-btn">
                     View on GitHub
                 </a>
                 <a href="#contribute" class="contribute-btn">
@@ -237,7 +237,7 @@
                     </div>
                 </div>
             </div>
-            <a href="https://github.com/YadavAkhileshh/OpenPlayground#readme" target="_blank" class="source-code-btn">
+            <a href="https://github.com/YadavAkhileshh/OpenPlayground#readme" target="_blank" rel="noopener noreferrer" class="source-code-btn">
                 Read Full Guide
             </a>
         </div>


### PR DESCRIPTION
## Security Enhancement 🔒

### Changes Made
Added `rel="noopener noreferrer"` to external GitHub links for security:
1. "View on GitHub" button (line 36)
2. "Read Full Guide" button (line 155)

### Why This Matters
- Prevents `window.opener` security vulnerability
- Follows web security best practices
- External links with `target="_blank"` should always use `rel="noopener noreferrer"`

### Testing Verified
- ✅ All 8 project links work correctly
- ✅ Internal `#contribute` link scrolls properly
- ✅ External links open securely in new tabs

This PR is for **ECWoC 2026** participation.
Fixes #23 