### PR TITLE
feat: separate New Game and Reset actions with updated styling

### DIFF
--- a/projects/tic-tac-toe/index.html
+++ b/projects/tic-tac-toe/index.html
@@ -13,7 +13,7 @@
         <h1>Tic Tac Toe</h1>
         <div class="game-info">
             <p id="status">Player X's Turn</p>
-            <button id="restart" class="btn">Restart Game</button>
+            <button id="restart" class="btn">New Game</button>
         </div>
         <div class="game-board" id="board">
             <div class="cell" data-index="0"></div>
@@ -25,6 +25,9 @@
             <div class="cell" data-index="6"></div>
             <div class="cell" data-index="7"></div>
             <div class="cell" data-index="8"></div>
+        </div>
+        <div>
+            <button id="newGame" >Reset Game</button>
         </div>
         <a href="../../index.html" class="back-link">← Back to Projects</a>
     </div>

--- a/projects/tic-tac-toe/script.js
+++ b/projects/tic-tac-toe/script.js
@@ -1,6 +1,7 @@
 const cells = document.querySelectorAll('.cell');
 const statusText = document.getElementById('status');
 const restartBtn = document.getElementById('restart');
+const newBtn = document.getElementById('newGame');
 
 let currentPlayer = 'X';
 let gameActive = true;
@@ -79,7 +80,7 @@ function highlightWinningCells(cells) {
     });
 }
 
-function restartGame() {
+function newGame() {
     currentPlayer = 'X';
     gameActive = true;
     gameState = ['', '', '', '', '', '', '', '', ''];
@@ -91,5 +92,20 @@ function restartGame() {
     });
 }
 
+function resetGame() {
+    gameState = ['', '', '', '', '', '', '', '', ''];
+    gameActive = true; // allow play again
+
+    cells.forEach(cell => {
+        cell.textContent = '';
+        cell.classList.remove('taken', 'x', 'o', 'winner');
+    });
+
+    statusText.textContent = `Game reset. Player ${currentPlayer}'s Turn`;
+}
+
 cells.forEach(cell => cell.addEventListener('click', handleCellClick));
-restartBtn.addEventListener('click', restartGame);
+
+restartBtn.addEventListener('click', resetGame);   // quick abort
+newBtn.addEventListener('click', newGame);          // fresh start
+

--- a/projects/tic-tac-toe/style.css
+++ b/projects/tic-tac-toe/style.css
@@ -46,12 +46,21 @@ h1 {
     padding: 0.8rem 2rem;
     font-size: 1rem;
     font-weight: 600;
-    background: linear-gradient(135deg, #4facfe, #00f2fe);
+    background: linear-gradient(135deg, #4facfe, #003249);
     color: white;
     border: none;
     border-radius: 25px;
     cursor: pointer;
     transition: all 0.3s ease;
+    font-family: 'Poppins', sans-serif;
+}
+#newGame{
+   padding: 0.8rem 2rem;
+    border: none;
+    border-radius: 20px;
+    cursor:pointer; 
+    transition: all 0.3s ease;
+    background: linear-gradient(135deg, #9AD1D4, #003249);
     font-family: 'Poppins', sans-serif;
 }
 


### PR DESCRIPTION
Hi @YadavAkhileshh ! This PR adds a quick Reset button and separates New Game and Reset actions for better UX.

## Summary
- Renamed existing "Restart" button to "New Game"
- Added a dedicated "Reset" button below the game board for quick mid-game reset
- Exchanged button positions to improve layout and UX
- Updated button styling for clarity and better visual hierarchy

## Motivation
Previously, the game only had a "Restart" button, which was unclear.
Now:
- "New Game" starts a fresh match
- "Reset" clears the board mid-game if a player quits or abandons
This improves usability and gameplay flow without breaking existing logic.

## Scope
- UI/UX improvements only
- No gameplay-breaking changes
- Fully mobile responsive

I’d appreciate your review when convenient. Thanks!

