### PR TITLE
Text Overflow in Hard Difficulty Mode

### DIFF
--- a/projects/typing-speed-test/style.css
+++ b/projects/typing-speed-test/style.css
@@ -239,6 +239,17 @@ body {
     margin-bottom: 1rem;
 }
 
+/* .text-display {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem;
+    min-height: 80px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 1rem;
+    line-height: 1.8;
+    color: var(--text-primary);
+} */
 .text-display {
     background: var(--bg-secondary);
     border: 1px solid var(--border);
@@ -249,7 +260,13 @@ body {
     font-size: 1rem;
     line-height: 1.8;
     color: var(--text-primary);
+
+    /*  Here is the Fix */
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
 }
+
 
 .text-display.active {
     border-color: var(--primary);


### PR DESCRIPTION
Text Overflow in Hard Difficulty Mode
<img width="1572" height="879" alt="Screenshot 2026-01-05 184243" src="https://github.com/user-attachments/assets/236c92a5-2da2-478b-b62a-b9cf5c7d8520" />


An issue was observed where long and complex sentences overflowed outside the text display container. This happened because hard-level content includes lengthy technical words and paragraphs, which were not being wrapped correctly by the container.

The root cause was missing word-wrapping rules in CSS


Solution

The issue was fixed by explicitly enabling safe text wrapping using modern CSS properties such as:

word-wrap: break-word

overflow-wrap: break-word

white-space: normal
<img width="1209" height="852" alt="Screenshot 2026-01-05 184228" src="https://github.com/user-attachments/assets/d2cd6fa6-97d4-4e8e-aee9-fb8cbbfd0f14" />


Result

Hard difficulty text now stays fully inside the display box

Layout remains consistent across all screen sizes

No JavaScript logic was modified => CSS fix

Improved readability and user experience for advanced users