### PR TITLE
fix: correct chatbot CSS class names to match stylesheet

### DIFF
--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -56,7 +56,7 @@
   function addMessage(text, sender) {
     if (!messages) return;
     const msg = document.createElement("div");
-    msg.className = sender === "user" ? "user-msg" : "bot-msg";
+    msg.className = sender === "user" ? "user-message" : "bot-message";
     msg.innerText = text;
     messages.appendChild(msg);
     messages.scrollTop = messages.scrollHeight;
@@ -92,7 +92,7 @@
     if (!messages) return;
 
     const div = document.createElement("div");
-    div.className = "bot-msg";
+    div.className = "bot-message";
     messages.appendChild(div);
 
     let i = 0;


### PR DESCRIPTION
The chatbot.js was using 'user-msg' and 'bot-msg' class names, but the CSS file (style.css) defines 'user-message' and 'bot-message' classes.

This mismatch caused the chatbot messages to render without proper styling.

Changes:
- Updated addMessage() to use 'user-message' and 'bot-message'
- Updated typeMessage() to use 'bot-message'

Fixes chatbot styling inconsistency