### PR TITLE
fix: resolve 404 error for Random Idea Generator

### DIFF
--- a/components/projects.html
+++ b/components/projects.html
@@ -174,7 +174,7 @@
 </a>
 
         <!-- Random Idea Generator -->
-        <a href="./projects/random-idea-generator/index.html" class="card" data-category="utility">
+        <a href="./projects/Random_Idea_Generator/index.html" class="card" data-category="utility">
             <div class="card-cover" style="background:linear-gradient(135deg,#667eea,#764ba2); color:white">
                 <i class="ri-lightbulb-flash-line"></i>
             </div>


### PR DESCRIPTION
Fixes the issue where the Random Idea Generator project was showing a 404 NOT_FOUND error.

- Corrected the broken route/link
- Ensured the project opens correctly

Closes #403
