### PR TITLE
Fix scroll-to-top button overlap and align it with chatbot button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1427,8 +1427,8 @@ html[data-theme="dark"] .section-badge {
    =============================== */
 #scrollToTopBtn {
     position: fixed;
-    bottom: var(--space-8);
-    right: var(--space-8);
+    bottom: calc(var(--space-8) + 60px);
+    right: calc(var(--space-8) - 2px);
     width: 48px;
     height: 48px;
     border-radius: var(--radius-full);


### PR DESCRIPTION
## 🛠️ What was changed
- Adjusted the bottom spacing of the scroll-to-top button to prevent overlap with the chatbot button
- Fine-tuned the horizontal alignment so both buttons are vertically centered and visually aligned
- Changes are CSS-only, using existing design tokens for consistency

## ✅ Why this change
- The scroll-to-top button was partially hidden behind the chatbot button, making it hard to notice and interact with. This update ensures better visibility and a cleaner UI without affecting existing functionality.

## 📂 Files changed
css/style.css

## 📸 Video Recording

https://github.com/user-attachments/assets/0b83ed96-6046-41a0-be4e-a308cfe257ad

## 🧪 How to test
- Open the site and scroll to the bottom
- Verify that the scroll-to-top button is fully visible
- Confirm that it no longer overlaps the chatbot button and appears properly aligned

Closes #505 