### PR TITLE
fix: correct YMD age calculation and validate date input

### DIFF
--- a/projects/age-calculator/script.js
+++ b/projects/age-calculator/script.js
@@ -6,7 +6,11 @@ function calculateAge() {
     var inputDate = document.getElementById('date').value;
     var unit = document.getElementById('unitSelector').value;
 
-    var birthDate = new Date(inputDate);
+    if (!inputDate) {
+        result.innerText = "Please select a valid date.";
+        return;
+    }
+   var birthDate = new Date(inputDate);
     var currentDate = new Date();
 
     var timeDiff = currentDate - birthDate;
@@ -15,75 +19,61 @@ function calculateAge() {
         case 'years':
             var age = Math.floor(timeDiff / (1000 * 60 * 60 * 24 * 365.25));
             var units = 'years';
-            displayResult(age,units); 
+            displayResult(age, units);
             break;
         case 'months':
             var ageInMonths = Math.floor(timeDiff / (1000 * 60 * 60 * 24 * 30.44));
             var units = 'months';
-            displayResult(ageInMonths,units);
+            displayResult(ageInMonths, units);
             break;
         case 'days':
             var ageInDays = Math.floor(timeDiff / (1000 * 60 * 60 * 24));
             var units = 'days';
-            displayResult(ageInDays,units);
+            displayResult(ageInDays, units);
             break;
         case 'dogYears':
             var ageInDogYears = Math.floor(timeDiff / (1000 * 60 * 60 * 24 * 365.25) * 7); // Assuming 1 human year = 7 dog years
             var units = 'dog years';
-            displayResult(ageInDogYears,units);
-            break; 
-        case 'ymd': 
-
+            displayResult(ageInDogYears, units);
+            break;
+        case 'ymd': {
             let d1 = birthDate.getDate();
-            let m1 = birthDate.getMonth()+1;
+            let m1 = birthDate.getMonth();
             let y1 = birthDate.getFullYear();
 
             let d2 = currentDate.getDate();
-            let m2 = currentDate.getMonth() + 1;
+            let m2 = currentDate.getMonth();
             let y2 = currentDate.getFullYear();
 
-            let d3,m3,y3;
+            let y3 = y2 - y1;
+            let m3 = m2 - m1;
+            let d3 = d2 - d1;
 
-            y3 = y2 - y1;
-
-            if(m2 >= m1){
-                m3 = m2 - m1;
-            }
-            else{
-                y3--;
-                m3 = 12 + m2 - m1;
-            }
-            if(d2>=d1){
-                d3 = d2 - d1;
-            }
-            else{
+            if (d3 < 0) {
                 m3--;
-                d3 = getDayInMonth(y1,m1)+d2-d1;
+                d3 += new Date(y2, m2, 0).getDate();
             }
-            if(m3<0){
-                m3 = 11;
+
+            if (m3 < 0) {
                 y3--;
+                m3 += 12;
             }
-            result.innerHTML = `You are ${y3} years, ${m3} months and ${d3} days old!`; 
-            if (y3 === undefined || m3 === undefined || d3 === undefined ) {
-                var ageymd = NaN;
-                var units = "years, months and days"; 
-                displayResult(ageymd, units);
-            }
+
+            result.innerText = `You are ${y3} years, ${m3} months and ${d3} days old!`;
             break;
-        default:
-            alert('Invalid unit selected');
+        }
+
+    }
+
+    function displayResult(age, units) {
+        var resultElement = document.getElementById('result');
+        resultElement.textContent = 'You are ' + age + ' ' + units + ' old!';
+    }
+
+    function resetFields() {
+        const result = document.getElementById('result');
+        result.innerText = '';
+        document.getElementById('date').value = '';
+        document.getElementById('unitSelector').value = 'ymd';
     }
 }
-
-function displayResult(age, units) {
-    var resultElement = document.getElementById('result');
-    resultElement.textContent = 'You are ' + age + ' ' + units + ' old!';
-}
-
-function resetFields() {
-    const result = document.getElementById('result');
-    result.innerText = '';
-    document.getElementById('date').value = ''; 
-    document.getElementById('unitSelector').value = 'ymd';
-  }


### PR DESCRIPTION
## 🛠 Fix: Correct YMD age calculation and handle invalid input

### What was changed

* Fixed `ymd` (years–months–days) age calculation logic.
* Added validation for empty date input to prevent invalid calculations.
* Simplified date difference handling for better accuracy and readability.

### Why this change

* The previous `ymd` logic could produce incorrect or undefined results.
* Invalid or empty date input caused the calculation to fail silently.
* This update ensures consistent and reliable age calculation.

### Result

* YMD age calculation now works correctly.
* Users receive clear feedback when input is missing or invalid.

**Kindly review when convenient. Thanks!**


