### PR TITLE
Add toggle-switch and set toggle-theme

### DIFF
--- a/projects/battery-detector/index.html
+++ b/projects/battery-detector/index.html
@@ -1,14 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
   <meta charset="UTF-8" />
   <title>Device Battery Detector</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="style.css" />
 </head>
+
 <body>
 
   <main class="container">
+    <div class="theme-toggle">
+      <span>🌞</span>
+      <label class="switch">
+        <input type="checkbox" id="themeToggle" />
+        <span class="slider"></span>
+      </label>
+      <span>🌙</span>
+    </div>
+
+
     <h1>🔋 Device Battery Detector</h1>
     <p class="subtitle">Real-time battery information from your device</p>
 
@@ -32,4 +44,5 @@
 
   <script src="script.js"></script>
 </body>
+
 </html>

--- a/projects/battery-detector/script.js
+++ b/projects/battery-detector/script.js
@@ -10,6 +10,22 @@ function formatTime(seconds) {
   const minutes = Math.floor((seconds % 3600) / 60);
   return `${hours}h ${minutes}m`;
 }
+const themeToggle = document.getElementById("themeToggle");
+
+// Load saved theme
+if (localStorage.getItem("theme") === "dark") {
+  document.body.classList.add("dark");
+  themeToggle.checked = true;
+}
+
+// Toggle theme
+themeToggle.addEventListener("change", () => {
+  document.body.classList.toggle("dark");
+
+  const theme = document.body.classList.contains("dark") ? "dark" : "light";
+  localStorage.setItem("theme", theme);
+});
+
 
 function updateBatteryInfo(battery) {
   const levelPercent = Math.round(battery.level * 100);

--- a/projects/battery-detector/style.css
+++ b/projects/battery-detector/style.css
@@ -27,6 +27,67 @@
     margin: 0;
     font-size: 1.6rem;
   }
+  /* Toggle container */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+/* Switch */
+.switch {
+  position: relative;
+  width: 50px;
+  height: 26px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  background-color: #ccc;
+  border-radius: 34px;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  transition: 0.3s;
+}
+
+.slider::before {
+  content: "";
+  position: absolute;
+  height: 20px;
+  width: 20px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: 0.3s;
+}
+
+/* Checked state */
+input:checked + .slider {
+  background-color: #22c55e;
+}
+
+input:checked + .slider::before {
+  transform: translateX(24px);
+}
+
+/* Dark mode */
+body.dark {
+  background: #0f172a;
+  color: #e5e7eb;
+}
+
   
   .subtitle {
     margin: 6px 0 20px;


### PR DESCRIPTION
This PR adds a toggle switch to the project that allows users to switch between light and dark themes. The selected theme is saved in localStorage so the preference persists across page reloads.

**Changes included**

- Added a toggle switch in the UI to switch between light and dark mode
- Implemented dark CSS class for dark theme styling
-  Stored user theme preference in localStorage for persistence
- Updated styles to reflect theme changes

**Why this is needed**

- Enhances user experience and accessibility
- Allows users to choose a preferred theme
-  Makes the UI modern and more visually appealing

**Scope**

- UI improvement and theme functionality
- No changes to core battery logic