### PR TITLE
Fix broken coin image by adding heads and tails SVG assets

### DIFF
--- a/projects/flip-coin/heads.svg
+++ b/projects/flip-coin/heads.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="95" fill="#FFD700" stroke="#C9A227" stroke-width="6"/>
+  <circle cx="100" cy="100" r="80" fill="#FFEB8A" stroke="#C9A227" stroke-width="4"/>
+  <text x="100" y="115" text-anchor="middle"
+        font-size="36" font-weight="bold"
+        fill="#8A6F00"
+        font-family="Arial, Helvetica, sans-serif">
+    HEAD
+  </text>
+</svg>

--- a/projects/flip-coin/tails.svg
+++ b/projects/flip-coin/tails.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="95" fill="#C0C0C0" stroke="#8A8A8A" stroke-width="6"/>
+  <circle cx="100" cy="100" r="80" fill="#E6E6E6" stroke="#8A8A8A" stroke-width="4"/>
+  <text x="100" y="115" text-anchor="middle"
+        font-size="36" font-weight="bold"
+        fill="#555"
+        font-family="Arial, Helvetica, sans-serif">
+    TAIL
+  </text>
+</svg>


### PR DESCRIPTION
This PR fixes issue #796 
### Summary
This PR fixes the issue where the coin image was not displaying correctly
and a broken image icon appeared during the coin flip.

### Changes Made
- Added missing coin image assets (`heads.svg` and `tails.svg`)
- Ensured correct image paths in the `<img src="">`
- Verified that both heads and tails images render correctly on flip

### Issue Fixed
Fixes: Broken coin image displayed instead of heads/tails

### Screenshots
(Attach before/after screenshots if required)

### Checklist
- [x] Code follows project guidelines
- [x] Issue reproduced and fixed locally
- [x] No breaking changes introduced
<img width="1345" height="772" alt="fix" src="https://github.com/user-attachments/assets/15028544-93f2-403b-8cc4-d1e038864496" />
