### PR TITLE
Fix navbar overlap by reserving header placeholder space

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -419,6 +419,11 @@ button#themeToggle {
   transition: all var(--transition-slow);
 }
 
+/* Reserve space for sticky navbar */
+#header-placeholder {
+  height: 72px; /* matches navbar height */
+}
+
 .nav-container {
   max-width: 1280px;
   margin: 0 auto;


### PR DESCRIPTION
Prevents content from hiding behind sticky navbar

## 📌 Description
This PR fixes a layout issue where page content was partially hidden
behind the sticky navbar.
#issuecomment-3779308195

The fix reserves space using the existing `#header-placeholder`,
ensuring consistent layout across all pages without modifying
navbar behavior or structure.

## 🔗 Related Issue
Closes #
## 🛠 Type of Change
- [x] 🐛 Bug Fix — Non-breaking fix for a layout issue
- [x] 🎨 Style — UI/CSS improvement (no functionality change)

## 🧪 Testing
- [x] Tested on Chrome
- [x] Tested on Firefox
- [x] Tested on Mobile (responsive)
- [x] No console errors

## 📷 Screenshots
![screenshot](https://github.com/user-attachments/assets/0fc8b79c-8004-4587-8b6e-f33df4c30c7d)


## ✅ Checklist
- [x] I have read the CONTRIBUTING.md guidelines
- [x] I have tested my changes locally
- [x] I have included screenshots where applicable
- [x] My code follows the project’s coding style
- [x] I have NOT modified any files unrelated to this change

## ℹ️ Additional Notes
This change strictly addresses the assigned issue only.
No unrelated files or bonus features were added.