### PR TITLE
Fix: Corrected Theme Toggle Icon Logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -362,39 +362,36 @@ button#themeToggle {
   transform-origin: center;
   transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }
+/* ===============================
+   FIXED Theme Toggle Logic
+   =============================== */
 
-[data-theme="light"] .theme-icon {
-  transform: rotate(0deg);
-}
-
-[data-theme="light"] .sun-core {
-  transform: scale(1);
-}
-
+/* LIGHT MODE → Show MOON */
 [data-theme="light"] .sun-rays {
-  transform: scale(1.1);
-  opacity: 1;
-}
-
-[data-theme="light"] .moon-bite {
-  transform: translate(20px, -20px);
-}
-
-[data-theme="dark"] .theme-icon {
-  transform: rotate(-10deg);
-}
-
-[data-theme="dark"] .sun-core {
-  transform: scale(1.4);
-}
-
-[data-theme="dark"] .sun-rays {
   transform: scale(0.1);
   opacity: 0;
 }
 
-[data-theme="dark"] .moon-bite {
+[data-theme="light"] .sun-core {
+  transform: scale(1.3);
+}
+
+[data-theme="light"] .moon-bite {
   transform: translate(5px, -1.5px) scale(0.6);
+}
+
+/* DARK MODE → Show SUN */
+[data-theme="dark"] .sun-rays {
+  transform: scale(1.1);
+  opacity: 1;
+}
+
+[data-theme="dark"] .sun-core {
+  transform: scale(1);
+}
+
+[data-theme="dark"] .moon-bite {
+  transform: translate(20px, -20px);
 }
 
 /* Shake Animation */


### PR DESCRIPTION
###Description:
 What This PR Does

Fixes inverted theme toggle icon logic.
Ensures the icon represents the next mode instead of the current mode.
Improves user experience and follows standard UI behavior.
Fixes:#2025
🧠 Before
Dark Mode → 🌙

Light Mode → ☀️
<img width="1270" height="374" alt="Screenshot 2026-02-02 191126" src="https://github.com/user-attachments/assets/34d5bdb9-8871-4a93-8e75-0d9b5677b0ef" />
✅ After

Dark Mode → ☀️

Light Mode → 🌙

<img width="1075" height="285" alt="image" src="https://github.com/user-attachments/assets/d6672682-6954-4559-a111-c4c157eb4cc9" />
