### PR TITLE
feat: Add Pathfinding Visualizer using A* algorithm

### DIFF
--- a/projects/PathfindingVisualizer/index.html
+++ b/projects/PathfindingVisualizer/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Pathfinding Visualizer (A*)</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<h1>🧠 Pathfinding Visualizer (A*)</h1>
+
+<div class="controls">
+  <button onclick="setMode('start')">Set Start</button>
+  <button onclick="setMode('end')">Set End</button>
+  <button onclick="setMode('wall')">Draw Walls</button>
+  <button onclick="runAStar()">Run A*</button>
+  <button onclick="resetGrid()">Reset</button>
+</div>
+
+<div id="grid"></div>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/projects/PathfindingVisualizer/project.json
+++ b/projects/PathfindingVisualizer/project.json
@@ -1,0 +1,9 @@
+{ 
+    "title": "Pathfinding Visualizer",
+    "category": "utility",
+    "difficulty": "Beginner", 
+    "description": "A utility project built with HTML, CSS, and JavaScript.", 
+    "tech": [ "HTML", "CSS", "JavaScript" ], 
+    "icon": "ri-tools-line", 
+    "coverStyle": "background: linear-gradient(135deg, #11998e 0%, #38ef7d 100%); color: white;" 
+}

--- a/projects/PathfindingVisualizer/script.js
+++ b/projects/PathfindingVisualizer/script.js
@@ -1,0 +1,156 @@
+const rows = 20;
+const cols = 20;
+const gridElement = document.getElementById("grid");
+
+let grid = [];
+let start = null;
+let end = null;
+let mode = "wall";
+
+function createGrid() {
+  grid = [];
+  gridElement.innerHTML = "";
+
+  for (let r = 0; r < rows; r++) {
+    let row = [];
+    for (let c = 0; c < cols; c++) {
+      const cell = document.createElement("div");
+      cell.className = "cell";
+      cell.dataset.row = r;
+      cell.dataset.col = c;
+      cell.onclick = () => handleClick(r, c, cell);
+      gridElement.appendChild(cell);
+
+      row.push({
+        row: r,
+        col: c,
+        f: 0,
+        g: 0,
+        h: 0,
+        wall: false,
+        parent: null
+      });
+    }
+    grid.push(row);
+  }
+}
+
+function setMode(m) {
+  mode = m;
+}
+
+function handleClick(r, c, cell) {
+  if (mode === "start") {
+    clearClass("start");
+    start = grid[r][c];
+    cell.classList.add("start");
+  } else if (mode === "end") {
+    clearClass("end");
+    end = grid[r][c];
+    cell.classList.add("end");
+  } else if (mode === "wall") {
+    grid[r][c].wall = true;
+    cell.classList.add("wall");
+  }
+}
+
+function clearClass(className) {
+  document.querySelectorAll("." + className)
+    .forEach(el => el.classList.remove(className));
+}
+
+function heuristic(a, b) {
+  return Math.abs(a.row - b.row) + Math.abs(a.col - b.col);
+}
+
+async function runAStar() {
+  if (!start || !end) return alert("Set start and end!");
+
+  let openSet = [start];
+  let closedSet = [];
+
+  while (openSet.length > 0) {
+
+    let lowest = 0;
+    for (let i = 0; i < openSet.length; i++) {
+      if (openSet[i].f < openSet[lowest].f)
+        lowest = i;
+    }
+
+    let current = openSet[lowest];
+
+    if (current === end) {
+      drawPath(current);
+      return;
+    }
+
+    openSet.splice(lowest, 1);
+    closedSet.push(current);
+
+    let neighbors = getNeighbors(current);
+
+    for (let neighbor of neighbors) {
+      if (closedSet.includes(neighbor) || neighbor.wall)
+        continue;
+
+      let tempG = current.g + 1;
+
+      let newPath = false;
+      if (!openSet.includes(neighbor)) {
+        newPath = true;
+        neighbor.h = heuristic(neighbor, end);
+        openSet.push(neighbor);
+      } else if (tempG < neighbor.g) {
+        newPath = true;
+      }
+
+      if (newPath) {
+        neighbor.g = tempG;
+        neighbor.f = neighbor.g + neighbor.h;
+        neighbor.parent = current;
+      }
+    }
+
+    await sleep(20);
+    colorCell(current.row, current.col, "visited");
+  }
+
+  alert("No Path Found!");
+}
+
+function getNeighbors(node) {
+  let neighbors = [];
+  let { row, col } = node;
+
+  if (row > 0) neighbors.push(grid[row - 1][col]);
+  if (row < rows - 1) neighbors.push(grid[row + 1][col]);
+  if (col > 0) neighbors.push(grid[row][col - 1]);
+  if (col < cols - 1) neighbors.push(grid[row][col + 1]);
+
+  return neighbors;
+}
+
+function drawPath(node) {
+  let temp = node;
+  while (temp.parent) {
+    colorCell(temp.row, temp.col, "path");
+    temp = temp.parent;
+  }
+}
+
+function colorCell(r, c, className) {
+  const index = r * cols + c;
+  gridElement.children[index].classList.add(className);
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function resetGrid() {
+  createGrid();
+  start = null;
+  end = null;
+}
+
+createGrid();

--- a/projects/PathfindingVisualizer/style.css
+++ b/projects/PathfindingVisualizer/style.css
@@ -1,0 +1,44 @@
+body {
+  font-family: Arial;
+  text-align: center;
+  padding: 20px;
+  background: linear-gradient(135deg, #f8fafc, #dbeafe);
+}
+
+h1 {
+  color: #1e293b;
+}
+
+.controls button {
+  padding: 6px 12px;
+  margin: 5px;
+  border-radius: 6px;
+  border: none;
+  background: #3b82f6;
+  color: white;
+  cursor: pointer;
+}
+
+.controls button:hover {
+  background: #2563eb;
+}
+
+#grid {
+  display: grid;
+  grid-template-columns: repeat(20, 25px);
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.cell {
+  width: 25px;
+  height: 25px;
+  border: 1px solid #e2e8f0;
+  background: white;
+}
+
+.start { background: #22c55e !important; }
+.end { background: #ef4444 !important; }
+.wall { background: #1e293b !important; }
+.visited { background: #93c5fd !important; }
+.path { background: #facc15 !important; }


### PR DESCRIPTION
# Pull Request

## 📋 Description
<!-- Provide a brief summary of your changes -->
The project allows users to create a grid, place start/end nodes, draw obstacles, and visualize the A* algorithm finding the shortest path.

✨ What’s Included
Fully interactive grid

A* search implementation

Manhattan distance heuristic

Animated node exploration

Shortest path reconstruction

Light gradient UI theme

## 🔗 Related Issue
<!-- Link the issue this PR addresses (e.g., "Fixes #123" or "Closes #123") -->
Fixes #2588 

## 📝 Type of Change
<!-- Mark the appropriate option with an "x" (e.g., [x]) -->

- [x] 🆕 **New Project** - Adding a new project to OpenPlayground
- [ ] 🐛 **Bug Fix** - Non-breaking fix for an issue
- [ ] ✨ **Enhancement** - Improvement to existing functionality
- [ ] 📚 **Documentation** - Updates to README, comments, or docs
- [ ] 🎨 **Style** - UI/CSS improvements (no functionality change)

## 📸 Screenshots
<img width="771" height="848" alt="Screenshot 2026-02-08 183155" src="https://github.com/user-attachments/assets/72006a11-8504-4e60-b46b-19ac8284bd3a" />
