### PR TITLE
Add view counter to project cards (closes #4459)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1654,6 +1654,50 @@ html[data-theme="dark"] .badge-hidden-gem {
   font-weight: 500;
 }
 
+/* View Counter Styles */
+.card-footer {
+  padding-top: var(--space-3);
+  margin-top: auto;
+  border-top: 1px solid var(--border-light);
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.view-counter {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  padding: var(--space-2) var(--space-2);
+  border-radius: var(--radius-sm);
+  transition: all var(--transition-base);
+  font-weight: 500;
+}
+
+.view-counter:hover {
+  color: var(--primary-500);
+  background: var(--bg-tertiary);
+}
+
+/* Dark mode adjustments */
+html[data-theme="dark"] .view-counter {
+  color: var(--text-muted);
+}
+
+html[data-theme="dark"] .view-counter:hover {
+  color: var(--primary-400);
+}
+
+/* List view adjustments */
+.list-card-meta .view-counter {
+  font-size: 0.8rem;
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  margin: 0 var(--space-2);
+}
+
 /* Pagination */
 .pagination-container {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -88,6 +88,9 @@
 
     <script src="./js/templates-loader.js"></script>
 
+    <!-- View Counter Feature - Issue #4459 -->
+    <script src="./js/viewCounter.js"></script>
+
     <script>
 
 

--- a/js/app.js
+++ b/js/app.js
@@ -571,7 +571,7 @@ class ProjectManager {
                 <div class="card" 
                      data-category="${this.escapeHtml(project.category)}" 
                      data-link="${this.escapeHtml(project.link)}"
-                     onclick="window.location.href='${this.escapeHtml(project.link)}'; event.stopPropagation();">
+                     onclick="window.viewCounter && window.viewCounter.incrementView('${this.escapeHtml(project.title)}'); window.location.href='${this.escapeHtml(project.link)}'; event.stopPropagation();">
                     <div class="card-actions">
                         <button class="preview-btn" 
                                 onclick="event.preventDefault(); event.stopPropagation(); window.openSandboxPreview(this);"
@@ -613,6 +613,11 @@ class ProjectManager {
                             </div>
                             <p class="card-description">${this.escapeHtml(project.description || '')}</p>
                             <div class="card-tech">${techHtml}</div>
+                            <div class="card-footer">
+                                <span class="view-counter" onclick="event.stopPropagation(); window.viewCounter && window.viewCounter.incrementView('${this.escapeHtml(project.title)}');">
+                                    👁️ ${(window.viewCounter?.getViewCount(project.title) || 0)} views
+                                </span>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -673,6 +678,9 @@ class ProjectManager {
                             <span class="category-tag">${this.capitalize(project.category)}</span>
                         </div>
                         <p class="list-card-description">${this.escapeHtml(project.description || '')}</p>
+                        <div class="list-card-meta">
+                            <span class="view-counter">👁️ ${(window.viewCounter?.getViewCount(project.title) || 0)}</span>
+                        </div>
                     </div>
                     <div class="list-card-actions">
                         <button class="preview-btn" 
@@ -697,7 +705,7 @@ class ProjectManager {
                             <i class="ri-calendar-line"></i>
                         </button>
                         <a href="${project.link}" class="view-btn" title="View Project"
-                           onclick="window.projectManagerInstance.trackProjectClick(${JSON.stringify(project).replace(/"/g, '&quot;')})">
+                           onclick="window.viewCounter && window.viewCounter.incrementView('${this.escapeHtml(project.title)}'); window.projectManagerInstance.trackProjectClick(${JSON.stringify(project).replace(/"/g, '&quot;')})">
                             <i class="ri-arrow-right-line"></i>
                         </a>
                     </div>

--- a/js/viewCounter.js
+++ b/js/viewCounter.js
@@ -1,0 +1,86 @@
+/**
+ * ViewCounter - Tracks project views using localStorage
+ * Manages view counts for all projects
+ */
+class ViewCounter {
+  constructor() {
+    this.storageKey = 'openplayground_view_counts';
+    this.counts = this.loadCounts();
+  }
+
+  /**
+   * Load all view counts from localStorage
+   */
+  loadCounts() {
+    try {
+      const stored = localStorage.getItem(this.storageKey);
+      return stored ? JSON.parse(stored) : {};
+    } catch (e) {
+      console.warn('⚠️ ViewCounter: Failed to load from localStorage', e);
+      return {};
+    }
+  }
+
+  /**
+   * Save counts to localStorage
+   */
+  saveCounts() {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.counts));
+    } catch (e) {
+      console.warn('⚠️ ViewCounter: Failed to save to localStorage', e);
+    }
+  }
+
+  /**
+   * Increment view count for a project
+   * @param {string|number} projectId - Project identifier (index or ID)
+   */
+  incrementView(projectId) {
+    const id = String(projectId);
+    this.counts[id] = (this.counts[id] || 0) + 1;
+    this.saveCounts();
+    return this.counts[id];
+  }
+
+  /**
+   * Get view count for a project
+   * @param {string|number} projectId - Project identifier
+   * @returns {number} View count (0 if never viewed)
+   */
+  getViewCount(projectId) {
+    return this.counts[String(projectId)] || 0;
+  }
+
+  /**
+   * Get all view counts
+   * @returns {object} Object with all project view counts
+   */
+  getAllCounts() {
+    return { ...this.counts };
+  }
+
+  /**
+   * Reset all view counts (for testing)
+   */
+  resetAll() {
+    this.counts = {};
+    this.saveCounts();
+  }
+
+  /**
+   * Get top N projects by views
+   * @param {number} limit - How many top projects to return
+   * @returns {array} Array of {id, count} sorted by views
+   */
+  getTopViewed(limit = 10) {
+    return Object.entries(this.counts)
+      .map(([id, count]) => ({ id, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, limit);
+  }
+}
+
+// Create global instance
+window.viewCounter = new ViewCounter();
+console.log('✅ ViewCounter initialized');


### PR DESCRIPTION
## Overview
Implements view counter feature for project cards and list items using localStorage.

## Changes
- Created `ViewCounter` class to track project views
- Displays eye icon with view count on each card
- Increments on card click and page navigation
- Persistent storage across browser sessions

## Features
✅ Card view: Shows "👁️ X views" at bottom of each card
✅ List view: Shows "👁️ X" in metadata area
✅ Real-time updates: Count increments immediately
✅ Persistent: Survives page reloads using localStorage
✅ Dark mode support: Seamless theme integration

## Screenshot
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/0464cb39-d5a1-418b-bf43-466b20c3806a" />

Closes #4459