### PR TITLE
fix: correct feedback page URL path in navbar and footer

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -99,7 +99,7 @@
             <i class="ri-bookmark-line"></i>
             <span>Bookmarks</span>
           </a>
-          <a href="feedback.html" class="footer-link">
+          <a href="pages/feedback.html" class="footer-link">
             <i class="ri-feedback-line"></i>
             <span>Feedback</span>
           </a>

--- a/components/header.html
+++ b/components/header.html
@@ -19,7 +19,7 @@
                 <i class="ri-rocket-line" aria-hidden="true"></i> Full-Stack
             </a>
             <a href="contact.html" class="nav-link">Contact</a>
-            <a href="feedback.html" class="nav-link">Feedback</a>
+            <a href="pages/feedback.html" class="nav-link">Feedback</a>
            
 
             <!-- Enhanced Theme Toggle -->

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -11,9 +11,9 @@
     <link href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css" rel="stylesheet">
     <script type="module" src="./js/core/notificationManager.js"></script>
     <script type="module" src="./js/core/validationEngine.js"></script>
-    <link rel="stylesheet" href="./css/style.css">
-    <link rel="stylesheet" href="css/feedback.css" />
-    <link rel="stylesheet" href="./css/footer.css">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/feedback.css" />
+    <link rel="stylesheet" href="../css/footer.css">
 </head>
 
 <body>


### PR DESCRIPTION
## 📋 Description
Fixed incorrect feedback page URL in navbar and footer. The feedback link was pointing to `feedback.html` instead of `pages/feedback.html`, causing a 404 "Cannot GET" error when clicked.

## 🔗 Related Issue
Fixes #4559

## 📝 Type of Change
- [x] 🐛 **Bug Fix** - Non-breaking fix for an issue

## 📸 Screenshots
 Before 
<img width="1033" height="554" alt="image" src="https://github.com/user-attachments/assets/2e316753-4195-407e-bbff-0fa1dd4c5009" />



 After 

<img width="1540" height="968" alt="image" src="https://github.com/user-attachments/assets/66cfcec4-e155-4c15-adf5-4faed155ea50" />


| (404 error screenshot) | (feedback page loading screenshot) |

## ✅ Checklist
### For All PRs
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] I have tested my changes locally
- [x] I have included screenshots of my changes
- [x] My code follows the project's coding style
- [x] I have NOT modified any files unrelated to my change

### For Bug Fixes / Enhancements
- [x] My changes ONLY address the specific issue mentioned
- [x] I have NOT added any "bonus" features or unrelated changes
- [x] I properly tested the fix/enhancement

## 🧪 Testing
- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on Mobile (responsive)
- [x] No console errors

## 📝 Additional Notes
Changed `href="feedback.html"` to `href="pages/feedback.html"` in `components/header.html` and `components/footer.html` since the path resolves relative to `index.html` (root), not the `components/` folder.