### PR TITLE
fix: add home navigation from About page (fixes #4562)

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -1,7 +1,7 @@
 <!-- NAVBAR -->
 <nav class="navbar" id="navbar">
     <div class="nav-container">
-        <a href="#" class="nav-logo">
+        <a href="index.html" class="nav-logo">
             <i class="ri-code-box-fill" aria-hidden="true"></i>
             <span>OpenPlayground</span>
         </a>

--- a/pages/about.html
+++ b/pages/about.html
@@ -36,7 +36,20 @@
       <div class="hero-gradient"></div>
       <div class="hero-grid"></div>
     </div>
-
+    <a href="../index.html" style="
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #c2670c;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 16px;
+  margin-bottom: 16px;
+  padding: 8px 16px;
+  border: 2px solid #c2670c;
+  border-radius: 8px;">
+  ← Back to Home
+</a>
     <div class="hero-content">
       <div class="hero-badge">
         <i class="ri-information-line"></i>


### PR DESCRIPTION
\## 📋 Description
Added home navigation from the About page so users can return 
to the home page without using the browser back button.

## 🔗 Related Issue
Fixes #4562

## 📝 Type of Change
- [ ] 🖼️ **New Project**
- [x] 🐛 **Bug Fix** - Non-breaking fix for an issue
- [ ] ✨ **Enhancement**
- [ ] 📄 **Documentation**
- [ ] 🎨 **Style**

## ✅ Checklist
### For All PRs
- [x] I have read the CONTRIBUTING.md guidelines
- [x] I have tested my changes locally
- [x] I have included screenshots of my changes
- [x] My code follows the project's coding style
- [x] I have NOT modified any files unrelated to my change

### For Bug Fixes / Enhancements
- [x] My changes ONLY address the specific issue mentioned
- [x] I have NOT added any "bonus" features or unrelated changes
- [x] I properly tested the fix/enhancement

## 🧪 Testing
- [x] Tested on Chrome
- [ ] Tested on Firefox
- [ ] Tested on Mobile (responsive)
- [x] No console errors

Before Changes:
<img width="1709" height="982" alt="image" src="https://github.com/user-attachments/assets/9a9062ae-8134-4b93-8e7c-45b460d3faf4" />
<img width="1709" height="984" alt="image" src="https://github.com/user-attachments/assets/cebdac9b-f25b-4f81-8166-c9e108707c45" />

After Changes:
<img width="1709" height="982" alt="image" src="https://github.com/user-attachments/assets/bac6fc95-199f-4f1e-b14f-1ec081361e51" />
<img width="1709" height="982" alt="image" src="https://github.com/user-attachments/assets/131f2ddb-ef95-412a-9cfb-61c9796438af" />
